### PR TITLE
Cleanup exit codes and improve malloc checks

### DIFF
--- a/src/malloc.c
+++ b/src/malloc.c
@@ -71,6 +71,11 @@ double **malloc_rank2_double(int n1, int n2)
 
   A = malloc_rank1(n1, sizeof(double *));
 
+  if(!space || !A) {
+    fprintf(stderr, "malloc_rank2_double failure\n");
+    exit(-1);
+  }
+
   for(i=0;i<n1;i++){
     A[i] = &(space[n2*i]);
     //A[i] = malloc_rank1(n2,sizeof(double *));
@@ -89,6 +94,11 @@ double ****malloc_rank4_double(int n1, int n2, int n3, int n4)
   space = malloc_rank1(n1*n2*n3*n4, sizeof(double));
 
   A = malloc_rank1(n1, sizeof(double *));
+
+  if(!space || !A) {
+    fprintf(stderr, "malloc_rank4_double failure\n");
+    exit(-1);
+  }
 
   for(i=0;i<n1;i++){
     A[i] = malloc_rank1(n2,sizeof(double *));

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -60,6 +60,22 @@ void ****malloc_rank4(int n1, int n2, int n3, int n4, int size)
   return A;
 }
 
+void *****malloc_rank5(int n1, int n2, int n3, int n4, int n5, int size)
+{
+  void *****A;
+
+  if ((A = (void *****)malloc(n1*sizeof(void ****))) == NULL) {
+    fprintf(stderr, "malloc_rank5 failure\n");
+    exit(-1);
+  }
+
+  for (int i = 0; i < N1; i++) {
+    A[i] = malloc_rank4(n2, n3, n4, n5, size);
+  }
+
+  return A;
+}
+
 double **malloc_rank2_double(int n1, int n2)
 {
 
@@ -108,22 +124,6 @@ double ****malloc_rank4_double(int n1, int n2, int n3, int n4)
         A[i][j][k] = &(space[n4*(k + n3*(j + n2*i))]);
       }
     }
-  }
-
-  return A;
-}
-
-void *****malloc_rank5(int n1, int n2, int n3, int n4, int n5, int size)
-{
-  void *****A;
-
-  if ((A = (void *****)malloc(n1*sizeof(void ****))) == NULL) {
-    fprintf(stderr, "malloc_rank5 failure\n");
-    exit(-1);
-  }
-
-  for (int i = 0; i < N1; i++) {
-    A[i] = malloc_rank4(n2, n3, n4, n5, size);
   }
 
   return A;

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -6,7 +6,7 @@ void *malloc_rank1(int n1, int size)
 
   if((A = (void *)malloc(n1*size)) == NULL){
     fprintf(stderr,"malloc failure in malloc_rank1\n");
-    exit(123);
+    exit(-1);
   }
 
   return A;

--- a/src/par.c
+++ b/src/par.c
@@ -11,7 +11,7 @@ void load_par (const char *fname, Params *params) {
 
   if (fp == NULL) {
     fprintf(stderr, "! unable to load parameter file '%s'. (%d: %s)\n", fname, errno, strerror(errno));
-    exit(errno);
+    exit(-1);
   }
 
   // set default values here

--- a/src/track_super_photon.c
+++ b/src/track_super_photon.c
@@ -91,7 +91,7 @@ void track_super_photon(struct of_photon *ph)
           fprintf(stderr, "Xi, %g %g %g %g\n", Xi[0], Xi[1], Xi[2], Xi[3]);
           fprintf(stderr, "Ki, %g %g %g %g\n", Ki[0], Ki[1], Ki[2], Ki[3]);
           fprintf(stderr, "dKi, %g %g %g %g\n", dKi[0], dKi[1], dKi[2], dKi[3]);
-          exit(1);
+          exit(-1);
         }
       }
 


### PR DESCRIPTION
* Use negative exit codes all the time except from main().  This allows the user to use the return code to decide if the job should be retried, e.g., on the open science grid.

* Inserted more checks in malloc_rank2_double() and malloc_rank4_double().

* Reordered malloc functions to improve readability.