### PR TITLE
add target mdot feature

### DIFF
--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -720,7 +720,8 @@ void init_data(int argc, char *argv[], Params *params)
 
     bias_norm += dV*geom[i][j].gzone * Thetae*Thetae;
 
-    if (10 <= i && i <= 20) {
+    //if (10 <= i && i <= 20) {  // legacy code, removed to make ipole and igrmonty match
+    if (i <= 20) {
       lower(Ucon, geom[i][j].gcov, Ucov);
       dMact += geom[i][j].gzone*dx[2]*dx[3]*p[KRHO][i][j][k]*Ucon[1];
       Ladv += geom[i][j].gzone*dx[2]*dx[3]*p[UU][i][j][k]*Ucon[1]*Ucov[0];
@@ -728,16 +729,16 @@ void init_data(int argc, char *argv[], Params *params)
 
   }
 
-  dMact /= 11.;
+  dMact /= 21.;
 
   if (target_mdot > 0) {
-    fprintf(stderr, "Resetting M_unit to match target Mdot/MdotEdd = %g\n", target_mdot);
+    fprintf(stderr, "Resetting M_unit to match target Mdot/MdotEdd = %g ", target_mdot);
 
     double MdotEdd = 4. * M_PI * GNEWT * MBH * MP / ( SIGMA_THOMSON * CL * 0.1 );
     double Mdot = dMact * M_unit / T_unit;
     double mdot = Mdot / MdotEdd;
 
-    fprintf(stderr, "... was %g  is now %g\n", M_unit, fabs(M_unit * target_mdot / mdot));
+    fprintf(stderr, "... is now %g\n", fabs(M_unit * target_mdot / mdot));
 
     M_unit *= fabs(target_mdot / mdot);
 

--- a/src/par.c
+++ b/src/par.c
@@ -20,6 +20,8 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
   params->trat_large = 10.;
   params->Thetae_max = 1.e100;
 
+  params->mdot = 0;  // zero default value means ignore
+
   // Load parameters
   for (int i=0; i<argc-1; ++i) {
     if ( strcmp(argv[i], "-par") == 0 ) {
@@ -50,6 +52,7 @@ void load_par (const char *fname, Params *params) {
     read_param(line, "Ns", &(params->Ns), TYPE_DBL);
     read_param(line, "MBH", &(params->MBH), TYPE_DBL);
     read_param(line, "M_unit", &(params->M_unit), TYPE_DBL);
+    read_param(line, "mdot", &(params->mdot), TYPE_DBL);
     read_param(line, "dump", (void *)(params->dump), TYPE_STR);
     read_param(line, "spectrum", (void *)(params->spectrum), TYPE_STR);
 

--- a/src/par.c
+++ b/src/par.c
@@ -28,6 +28,11 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
       load_par(argv[i+1], params);
     }
   }
+
+  // override parameters based on what has been loaded
+  if (params->mdot > 0) {
+    params->M_unit = 1.;
+  }
 }
 
 // sets default values for elements of params (if desired) and loads

--- a/src/par.h
+++ b/src/par.h
@@ -19,6 +19,7 @@ typedef struct params_t {
   double Ns;
   double MBH;
   double M_unit;
+  double mdot;  // in units of MdotEddington
   const char dump[256];
   const char spectrum[256];
 


### PR DESCRIPTION
If specified, this choice overrides M_unit. For now, it's still necessary to set a "trial" non-zero M_unit so that the code has a (non-zero) fiducial value of mdot to compare the target mdot against. This requirement could be removed in the future by automatically setting M_unit = 1 if mdot > 0. See discussion https://github.com/AFD-Illinois/ipole/pull/81